### PR TITLE
More threads

### DIFF
--- a/Mandelbrot_Set.pde
+++ b/Mandelbrot_Set.pde
@@ -11,13 +11,17 @@ int iterations = 100;
 
 int renderTime = 0;
 int px_thrad;
+int nThreads = 16;
+
+Render[] render;
 
 Button button_increaseIterations;
 Button button_decreaseIterations;
 
 void setup() {
   size(700, 700);
-  px_thrad = width * height / 16;
+  px_thrad = width * height / nThreads;
+  render = new Render[nThreads];
   
   button_increaseIterations = new Button (20, height-50, 25, 25);
   button_increaseIterations.setColor(200,200,200);
@@ -26,80 +30,28 @@ void setup() {
   button_decreaseIterations = new Button (20, height-20, 25, 25);
   button_decreaseIterations.setColor(200,200,200);
   button_decreaseIterations.setName("-");
+  
 }
 
 void draw() {
   
-  
   loadPixels();
   renderTime = millis();
   
-  Render r1 = new Render(1, 0, px_thrad, width, height);
-  Render r2 = new Render(2, px_thrad, px_thrad*2, width, height);
-  Render r3 = new Render(3, px_thrad*2, px_thrad*3, width, height);
-  Render r4 = new Render(4, px_thrad*3, px_thrad*4, width, height);
-  Render r5 = new Render(5, px_thrad*4, px_thrad*5, width, height);
-  Render r6 = new Render(6, px_thrad*5, px_thrad*6, width, height);
-  Render r7 = new Render(7, px_thrad*6, px_thrad*7, width, height);
-  Render r8 = new Render(8, px_thrad*7, px_thrad*8, width, height);
-  Render r9 = new Render(9, px_thrad*8, px_thrad*9, width, height);
-  Render r10 = new Render(10, px_thrad*9, px_thrad*10, width, height);
-  Render r11 = new Render(11, px_thrad*10, px_thrad*11, width, height);
-  Render r12 = new Render(12, px_thrad*11, px_thrad*12, width, height);
-  Render r13 = new Render(13, px_thrad*12, px_thrad*13, width, height);
-  Render r14 = new Render(14, px_thrad*13, px_thrad*14, width, height);
-  Render r15 = new Render(15, px_thrad*14, px_thrad*15, width, height);
-  Render r16 = new Render(16, px_thrad*15, px_thrad*16, width, height);
+  for (int i = 0; i< nThreads; i++){
+    render[i] = new Render(i+1, px_thrad*i, px_thrad*(i+1), width, height);
+  }
   
-  r1.start();
-  r2.start();
-  r3.start();
-  r4.start();
-  r5.start();
-  r6.start();
-  r7.start();
-  r8.start();
-  r9.start();
-  r10.start();
-  r11.start();
-  r12.start();
-  r13.start();
-  r14.start();
-  r15.start();
-  r16.start();
+  for (int i = 0; i< nThreads; i++){
+    render[i].start();
+  }
   
-  try {r1.join();}
-  catch (InterruptedException e) {}
-  try {r2.join();}
-  catch (InterruptedException e) {}
-  try {r3.join();}
-  catch (InterruptedException e) {}
-  try {r4.join();}
-  catch (InterruptedException e) {}
-  try {r5.join();}
-  catch (InterruptedException e) {}
-  try {r6.join();}
-  catch (InterruptedException e) {}
-  try {r7.join();}
-  catch (InterruptedException e) {}
-  try {r8.join();}
-  catch (InterruptedException e) {}
-  try {r9.join();}
-  catch (InterruptedException e) {}
-  try {r10.join();}
-  catch (InterruptedException e) {}
-  try {r11.join();}
-  catch (InterruptedException e) {}
-  try {r12.join();}
-  catch (InterruptedException e) {}
-  try {r13.join();}
-  catch (InterruptedException e) {}
-  try {r14.join();}
-  catch (InterruptedException e) {}
-  try {r15.join();}
-  catch (InterruptedException e) {}
-  try {r16.join();}
-  catch (InterruptedException e) {}
+  for (int i = 0; i< nThreads; i++){
+    try {
+      render[i].join();
+    }
+    catch (InterruptedException e) {}
+  }
   
   print(" / " + (millis() - renderTime));
   

--- a/Mandelbrot_Set.pde
+++ b/Mandelbrot_Set.pde
@@ -3,13 +3,13 @@ int lastMouse_y;
 float dMouse_x = 0;
 float dMouse_y = 0;
 boolean last_pressed;
-long last_time = 0;
+int last_time = 0;
 float center_x = -0.7;
-float center_y = 0;
-float zoom = 2;
+float center_y = 1;
+float zoom = 1;
 int iterations = 100;
 
-long renderTime = 0;
+int renderTime = 0;
 int px_thrad;
 
 Button button_increaseIterations;
@@ -78,7 +78,7 @@ void draw() {
     last_pressed = false;
   }
   
-  long time = millis() - last_time;
+  int time = millis() - last_time;
   last_time = millis();
   println(" # " + time);
 }

--- a/Mandelbrot_Set.pde
+++ b/Mandelbrot_Set.pde
@@ -17,7 +17,7 @@ Button button_decreaseIterations;
 
 void setup() {
   size(700, 700);
-  px_thrad = width * height / 4;
+  px_thrad = width * height / 16;
   
   button_increaseIterations = new Button (20, height-50, 25, 25);
   button_increaseIterations.setColor(200,200,200);
@@ -34,25 +34,71 @@ void draw() {
   loadPixels();
   renderTime = millis();
   
-  Render r1 = new Render(0, px_thrad, width, height);
-  Render r2 = new Render(px_thrad, px_thrad*2, width, height);
-  Render r3 = new Render(px_thrad*2, px_thrad*3, width, height);
-  Render r4 = new Render(px_thrad*3, px_thrad*4, width, height);
+  Render r1 = new Render(1, 0, px_thrad, width, height);
+  Render r2 = new Render(2, px_thrad, px_thrad*2, width, height);
+  Render r3 = new Render(3, px_thrad*2, px_thrad*3, width, height);
+  Render r4 = new Render(4, px_thrad*3, px_thrad*4, width, height);
+  Render r5 = new Render(5, px_thrad*4, px_thrad*5, width, height);
+  Render r6 = new Render(6, px_thrad*5, px_thrad*6, width, height);
+  Render r7 = new Render(7, px_thrad*6, px_thrad*7, width, height);
+  Render r8 = new Render(8, px_thrad*7, px_thrad*8, width, height);
+  Render r9 = new Render(9, px_thrad*8, px_thrad*9, width, height);
+  Render r10 = new Render(10, px_thrad*9, px_thrad*10, width, height);
+  Render r11 = new Render(11, px_thrad*10, px_thrad*11, width, height);
+  Render r12 = new Render(12, px_thrad*11, px_thrad*12, width, height);
+  Render r13 = new Render(13, px_thrad*12, px_thrad*13, width, height);
+  Render r14 = new Render(14, px_thrad*13, px_thrad*14, width, height);
+  Render r15 = new Render(15, px_thrad*14, px_thrad*15, width, height);
+  Render r16 = new Render(16, px_thrad*15, px_thrad*16, width, height);
+  
   r1.start();
   r2.start();
   r3.start();
   r4.start();
+  r5.start();
+  r6.start();
+  r7.start();
+  r8.start();
+  r9.start();
+  r10.start();
+  r11.start();
+  r12.start();
+  r13.start();
+  r14.start();
+  r15.start();
+  r16.start();
   
   try {r1.join();}
   catch (InterruptedException e) {}
-  
   try {r2.join();}
   catch (InterruptedException e) {}
-  
   try {r3.join();}
   catch (InterruptedException e) {}
-  
   try {r4.join();}
+  catch (InterruptedException e) {}
+  try {r5.join();}
+  catch (InterruptedException e) {}
+  try {r6.join();}
+  catch (InterruptedException e) {}
+  try {r7.join();}
+  catch (InterruptedException e) {}
+  try {r8.join();}
+  catch (InterruptedException e) {}
+  try {r9.join();}
+  catch (InterruptedException e) {}
+  try {r10.join();}
+  catch (InterruptedException e) {}
+  try {r11.join();}
+  catch (InterruptedException e) {}
+  try {r12.join();}
+  catch (InterruptedException e) {}
+  try {r13.join();}
+  catch (InterruptedException e) {}
+  try {r14.join();}
+  catch (InterruptedException e) {}
+  try {r15.join();}
+  catch (InterruptedException e) {}
+  try {r16.join();}
   catch (InterruptedException e) {}
   
   print(" / " + (millis() - renderTime));

--- a/Mandelbrot_Set.pde
+++ b/Mandelbrot_Set.pde
@@ -9,6 +9,7 @@ float center_y = 0;
 float zoom = 2;
 int iterations = 100;
 
+long renderTime = 0;
 int px_thrad;
 
 Button button_increaseIterations;
@@ -28,11 +29,10 @@ void setup() {
 }
 
 void draw() {
-  long time = millis() - last_time;
-  last_time = millis();
-  println("Time: " + time + " ms");
+  
   
   loadPixels();
+  renderTime = millis();
   
   Render r1 = new Render(0, px_thrad, width, height);
   Render r2 = new Render(px_thrad, px_thrad*2, width, height);
@@ -55,6 +55,8 @@ void draw() {
   try {r4.join();}
   catch (InterruptedException e) {}
   
+  print(" / " + (millis() - renderTime));
+  
   updatePixels();
   
   //Interface
@@ -75,6 +77,10 @@ void draw() {
   }else{
     last_pressed = false;
   }
+  
+  long time = millis() - last_time;
+  last_time = millis();
+  println(" # " + time);
 }
 
 class Point {

--- a/Render_thread.pde
+++ b/Render_thread.pde
@@ -1,4 +1,5 @@
 class Render extends Thread {
+  int threadNum;
   int origin;
   int end;
   int image_width;
@@ -6,7 +7,8 @@ class Render extends Thread {
   Point pixel;
   color pColor;
   
-  Render(int origin, int end, int image_width, int image_height) {
+  Render(int threadNumber, int origin, int end, int image_width, int image_height) {
+    this.threadNum = threadNumber;
     this.origin = origin;
     this.end = end;
     this.image_width = image_width;
@@ -14,7 +16,7 @@ class Render extends Thread {
     pixel = new Point();
   }
   public void run() {
-    int start = millis();
+    //int start = millis();
     for (int i = origin; i < end; i++) {
       pixel = getPos(i, image_width);
      
@@ -49,7 +51,7 @@ class Render extends Thread {
       
       pixels[i] = pColor;
     }
-    int end = millis();
-    print(" " + (end - start));
+    //int end = millis();
+    //print(" * R"+ threadNum + " " + (end - start));
   }
 }

--- a/Render_thread.pde
+++ b/Render_thread.pde
@@ -14,7 +14,7 @@ class Render extends Thread {
     pixel = new Point();
   }
   public void run() {
-    long start = millis();
+    int start = millis();
     for (int i = origin; i < end; i++) {
       pixel = getPos(i, image_width);
      
@@ -49,6 +49,7 @@ class Render extends Thread {
       
       pixels[i] = pColor;
     }
-    print(" " + (millis() - start));
+    int end = millis();
+    print(" " + (end - start));
   }
 }

--- a/Render_thread.pde
+++ b/Render_thread.pde
@@ -14,7 +14,7 @@ class Render extends Thread {
     pixel = new Point();
   }
   public void run() {
-    
+    long start = millis();
     for (int i = origin; i < end; i++) {
       pixel = getPos(i, image_width);
      
@@ -49,5 +49,6 @@ class Render extends Thread {
       
       pixels[i] = pColor;
     }
+    print(" " + (millis() - start));
   }
 }


### PR DESCRIPTION
In order to test the performance, a 700x700 pixels image was rendered like the one below.
Having the Mandelbrot set at the bottom is a good and simple case where the effects of threads are more apparent. (More threads than the CPU can handle at the same time).
The CPU used during the test has 2 cores 4 threads.
The rendering is done dividing the image (vertical direction) in N parts, were N is the number of threads.

<img src="https://user-images.githubusercontent.com/31282394/48150902-3aa09200-e2c0-11e8-88ad-55517d8cb91b.png" width="60%">
